### PR TITLE
Update role name in integration tests

### DIFF
--- a/test/integration/users/default.yml
+++ b/test/integration/users/default.yml
@@ -5,8 +5,8 @@
   become_user: root
   become_method: sudo
   roles:
-    - { role: users, list: ['max','molly','sadie','charlie','zoe'] }
-    - { role: users, list: ['maggie'], sudo: 'nopasswd' }
+    - { role: ansible-role-users, list: ['max','molly','sadie','charlie','zoe'] }
+    - { role: ansible-role-users, list: ['maggie'], sudo: 'nopasswd' }
   vars:
     user_users:
       - name: max


### PR DESCRIPTION
Update the name of the role in the intergration test to match the name of
the repository (and hence the name of the Jenkins task) to ensure that it
is correctly run during tests by test-kitchen.
