### PR TITLE
Fix handling for when list is not defined

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,7 +3,7 @@
 
 - include: root.yml
   when:
-    "'root' in list"
+    list is defined and 'root' in list
 
 - include: groups-present.yml
 - include: users-present.yml


### PR DESCRIPTION
If `list` hasn't been set, the run will fail when trying to process `root` user when it should continue and add all known users.
