### PR TITLE
Bare Variables in Tasks Error

### DIFF
--- a/tasks/root.yml
+++ b/tasks/root.yml
@@ -17,6 +17,6 @@
     state: "{{ item.state | default(preset) }}"
     manage_dir: yes
   with_items:
-    users_root_ssh_keys
+    "{{ users_root_ssh_keys }}"
   tags:
     - user_keys


### PR DESCRIPTION
Fix an issue with `users_root_ssh_keys` not being correctly referenced in a task in this role.
